### PR TITLE
Changed drop event listener to use EventTarget

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -285,13 +285,13 @@
 	 **** Drag and drop ****
 	 ***********************/
 	// keep a reference to the original method
-	var _addEventListener = Element.prototype.addEventListener;
+	var _addEventListener = EventTarget.prototype.addEventListener;
 
 	DataTransfer.prototype[getFilesMethod] = function() {
 		return Promise.resolve([]);
 	};
 
-	Element.prototype.addEventListener = function(type, listener, useCapture) {
+	EventTarget.prototype.addEventListener = function(type, listener, useCapture) {
 		if (type === 'drop') {
 			var _listener = listener;
 


### PR DESCRIPTION
Switched `Element` to `EventTarget` so that the drop event could be attached to `document`. I'm not 100% sure if this has any other consequences but it seemed to fix it enough for my use case of attaching the handler to `document`.
